### PR TITLE
fix: Prevent spoofing with [Symbol.toStringTag]

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,18 @@
+'use strict';
 
 var hasOwn = Object.prototype.hasOwnProperty;
 var toString = Object.prototype.toString;
 
-module.exports = function forEach (obj, fn, ctx) {
-    if (toString.call(fn) !== '[object Function]') {
+var isFunction = typeof Symbol === 'function' && typeof Symbol.toStringTag === 'symbol' ?
+    function isFunction(fn) {
+        return typeof fn === 'function';
+    } :
+    function isFunction(fn) {
+        return toString.call(fn) === '[object Function]';
+    };
+
+module.exports = function forEach(obj, fn, ctx) {
+    if (!isFunction(fn)) {
         throw new TypeError('iterator must be a function');
     }
     var l = obj.length;
@@ -19,4 +28,3 @@ module.exports = function forEach (obj, fn, ctx) {
         }
     }
 };
-

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
+'use strict';
+
 var test = require('tape');
 var forEach = require('./index.js');
-
 
 test('second argument: iterator', function (t) {
     var arr = [];
@@ -151,3 +152,37 @@ test('string', function (t) {
     t.end();
 });
 
+
+test('Symbol.toStringTag', {
+    skip: typeof Symbol !== 'function' || typeof Symbol.toStringTag !== 'symbol'
+}, function (t) {
+    var arr = [1, 2, 3];
+
+    t['throws'](function () {
+        var callback = {};
+        callback[Symbol.toStringTag] = 'Function';
+
+        forEach(arr, callback);
+    }, 'non-function with spoofed [Symbol.toStringTag] is rejected');
+
+    t.test('callback with custom [Symbol.toStringTag]', function (st) {
+        st.plan(2 + (arr.length * 2))
+
+        var counter = 0;
+        var callback = function (item, index) {
+            st.equal(arr[index], item, 'item ' + index + ' is passed as first argument');
+            st.equal(counter, index, 'index ' + index + ' is passed as second argument');
+            counter++;
+        };
+        callback[Symbol.toStringTag] = 'Custom callback';
+
+        st.doesNotThrow(function () {
+            forEach(arr, callback);
+        });
+
+        st.equal(counter, arr.length, 'iterates ' + arr.length + ' times');
+        st.end();
+    });
+
+    t.end();
+});


### PR DESCRIPTION
Currently, `forEach` uses `toString.call(fn) !== '[object Function]'` to detect whether the callback is a valid function, but this doesn’t work in environments that have `Symbol.toStringTag`.

This fixes that to account for objects with a spoofed `[Symbol.toStringTag]` property and functions with a custom `[Symbol.toStringTag]` property.